### PR TITLE
fix tensor device type incompatibility

### DIFF
--- a/kaldifeat/python/kaldifeat/offline_feature.py
+++ b/kaldifeat/python/kaldifeat/offline_feature.py
@@ -69,7 +69,7 @@ class OfflineFeature(nn.Module):
             for w in waves
         ]
 
-        strided = [self.convert_samples_to_frames(w) for w in waves]
+        strided = [self.convert_samples_to_frames(w.to(self.opts.device)) for w in waves]
         strided = torch.cat(strided, dim=0)
 
         features = self.compute(strided, vtln_warp)


### PR DESCRIPTION
When I tried to extract fbank with this code:

```
opts = kaldifeat.FbankOptions()
opts.device = torch.device('cuda', 0)
opts.frame_opts.window_type = 'povey'
fbank = kaldifeat.Fbank(opts)
features = fbank(wave)
```

I got this error

```
Traceback (most recent call last):
  File "extract_feature.py", line 15, in <module>
    features = fbank(wave)
  File "/path/to/anaconda3/envs/general/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/path/to/anaconda3/envs/general/lib/python3.8/site-packages/kaldifeat-1.10-py3.8-linux-x86_64.egg/kaldifeat/offline_feature.py", line 75, in forward
    features = self.compute(strided, vtln_warp)
  File "/path/to/anaconda3/envs/general/lib/python3.8/site-packages/kaldifeat-1.10-py3.8-linux-x86_64.egg/kaldifeat/offline_feature.py", line 111, in compute
    features = self.computer.compute_features(x, vtln_warp)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Hence I added `.to(device)` to related tensor