### PR TITLE
Fix chunk size

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include LICENSE
+include README.md
 include CMakeLists.txt
 exclude pyproject.toml
 recursive-include kaldifeat *.*

--- a/kaldifeat/python/kaldifeat/offline_feature.py
+++ b/kaldifeat/python/kaldifeat/offline_feature.py
@@ -122,7 +122,7 @@ class OfflineFeature(nn.Module):
                 )
                 features.append(this_chunk)
             if end < x.size(0):
-                last_chunk = self.compute_features(x[end:], vtln_warp)
+                last_chunk = self.computer.compute_features(x[end:], vtln_warp)
                 features.append(last_chunk)
             features = torch.cat(features, dim=0)
 

--- a/kaldifeat/python/kaldifeat/offline_feature.py
+++ b/kaldifeat/python/kaldifeat/offline_feature.py
@@ -72,7 +72,7 @@ class OfflineFeature(nn.Module):
         strided = [self.convert_samples_to_frames(w) for w in waves]
         strided = torch.cat(strided, dim=0)
 
-        features = self.compute(strided, vtln_warp)
+        features = self.compute(strided, vtln_warp, chunk_size=chunk_size)
 
         if is_list:
             return list(features.split(num_frames_per_wave))

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
     version=get_package_version(),
     author="Fangjun Kuang",
     author_email="csukuangfj@gmail.com",
-    data_files=[("", ["LICENSE", "README.md"])],
     package_dir={package_name: "kaldifeat/python/kaldifeat"},
     packages=[package_name],
     url="https://github.com/csukuangfj/kaldifeat",


### PR DESCRIPTION
Chunk size was not used in computing features and it causes OOM for some utterances in GigaSpeech, e.g., for the following utterance, which has 32923.58 seconds, i.e., 9.145 hours.

![Screen Shot 2021-11-29 at 07 15 47](https://user-images.githubusercontent.com/5284924/143790271-3f3866b5-ba91-496c-af43-8cbbdf47730b.png)

This PR fixes that.
