### PR TITLE
changes for using C++ API by other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,13 +42,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 message(STATUS "C++ Standard version: ${CMAKE_CXX_STANDARD}")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 
 option(kaldifeat_BUILD_TESTS "Whether to build tests or not" ON)
+option(kaldifeat_BUILD_PYMODULE "Whether to build python module or not" ON)
 
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(kaldifeat_BUILD_PYMODULE)
   include(pybind11)
 endif()
 
@@ -72,7 +73,7 @@ if(WIN32)
   endforeach()
 endif()
 
-include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 

--- a/kaldifeat/CMakeLists.txt
+++ b/kaldifeat/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(csrc)
-add_subdirectory(python)
+if(kaldifeat_BUILD_PYMODULE)
+  add_subdirectory(python)
+endif()


### PR DESCRIPTION
I use the C++ API in wenet runtime with FetchContent. But kaldifeat's CMakeLists.txt use CMAKE_SOURCE_DIR, which is path to wenet/runtime/libtorch, then kaldifeat couldn't find its own cmake module. so, I make two changes to make kaldifeat working fine as a dependenty project to other projects.:

1. change it to CMAKE_CURRENT_SOURCE_DIR.
2. add option `kaldifeat_BUILD_PYMODULE`, which can be set OFF by other projects. we only use C++ api, but kaldifeat default to build python module by `add_subdirectory(python)`

But, without these changes, kaldifeat works fine with k2, why? 
Because there're cmake modules in `k2/cmake/` used by kaldifeat, in other words, kaldifeat use k2's cmake modules not its own.

~~With the 2nd change, k2 needs set `kaldifeat_BUILD_PYMODULE` to OFF in k2/cmake/kaldifeat.cmake.~~ k2 needs no change.