### PR TITLE
Allow all zero rows in mel computation matrix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(kaldifeat)
 # remember to change the version in
 # scripts/conda/kaldifeat/meta.yaml
 # scripts/conda-cpu/kaldifeat/meta.yaml
-set(kaldifeat_VERSION "1.25.4")
+set(kaldifeat_VERSION "1.25.5")
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/kaldifeat/csrc/mel-computations.cc
+++ b/kaldifeat/csrc/mel-computations.cc
@@ -138,7 +138,7 @@ MelBanks::MelBanks(const MelBanksOptions &opts,
                   << " and vtln-high " << vtln_high << ", versus "
                   << "low-freq " << low_freq << " and high-freq " << high_freq;
 
-  // we will transpose bins_mat_ at the end of this funciton
+  // we will transpose bins_mat_ at the end of this function
   bins_mat_ = torch::zeros({num_bins, num_fft_bins}, torch::kFloat);
 
   int32_t stride = bins_mat_.strides()[0];
@@ -179,12 +179,14 @@ MelBanks::MelBanks(const MelBanksOptions &opts,
         last_index = i;
       }
     }
-    KALDIFEAT_ASSERT(first_index != -1 && last_index >= first_index &&
-                     "You may have set num_mel_bins too large.");
+
+    // Note: It is possible that first_index == last_index == -1 at this line.
 
     // Replicate a bug in HTK, for testing purposes.
-    if (opts.htk_mode && bin == 0 && mel_low_freq != 0.0f)
+    if (opts.htk_mode && bin == 0 && mel_low_freq != 0.0f &&
+        first_index != -1) {
       this_bin[first_index] = 0.0f;
+    }
   }
 
   if (debug_) KALDIFEAT_LOG << bins_mat_;

--- a/scripts/conda-cpu/kaldifeat/meta.yaml
+++ b/scripts/conda-cpu/kaldifeat/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: kaldifeat
-  version: "1.25.4"
+  version: "1.25.5"
 
 source:
   path: "{{ environ.get('KALDIFEAT_ROOT_DIR') }}"

--- a/scripts/conda/kaldifeat/meta.yaml
+++ b/scripts/conda/kaldifeat/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: kaldifeat
-  version: "1.25.4"
+  version: "1.25.5"
 
 source:
   path: "{{ environ.get('KALDIFEAT_ROOT_DIR') }}"


### PR DESCRIPTION
```python3
import kaldifeat

opts = kaldifeat.FbankOptions()
opts.frame_opts.samp_freq = 8000
opts.mel_opts.num_bins = 128

fbank = kaldifeat.Fbank(opts)
```

throws the following error:
```
x: first_index != -1 && last_index >= first_index && "You may have set num_mel_bins too large."
```

However, in lhotse, the following code runs correctly
```python3
from lhotse import *

extractor = Fbank(FbankConfig(num_mel_bins=128, sampling_rate=8000))
```

And if we use
<img width="844" alt="Screenshot 2024-09-14 at 12 01 03" src="https://github.com/user-attachments/assets/a7f1c24f-94dc-41e2-979d-f77b93dcae13">

We can see that it allows rows to contain all zeros in the matrix.

This PR updates the C++ code in kaldifeat to match that.